### PR TITLE
Added zkeyExportSwayCalldata

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -13297,7 +13297,7 @@ async function zkeyExportSwayCalldata(params, options) {
     proof: proof
   };
 
-  console.log(res);
+  console.log(JSON.stringify(res));
 
   return 0;
 }

--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -12782,7 +12782,7 @@ const commands = [
         cmd: "zkey export swaycalldata [public.json] [proof.json]",
         description: "Generates sway call parameters ready to be called.",
         alias: ["zkeswc", "generateswaycall -pub|public -p|proof"],
-        //action: zkeyExportSwayCalldata
+        action: zkeyExportSwayCalldata
     },
     {
         cmd: "groth16 setup [circuit.r1cs] [powersoftau.ptau] [circuit_0000.zkey]",
@@ -13268,6 +13268,38 @@ async function zkeyExportSwayVerifier(params, options) {
     fs__default["default"].writeFileSync(path__default["default"].join(verifierDir, "main.sw"), mainCode, "utf-8");
 
     return 0;
+}
+
+
+async function zkeyExportSwayCalldata(params, options) {
+  let publicName;
+  let proofName;
+
+  if (params.length < 1) {
+      publicName = "public.json";
+  } else {
+      publicName = params[0];
+  }
+
+  if (params.length < 2) {
+      proofName = "proof.json";
+  } else {
+      proofName = params[1];
+  }
+
+  if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
+
+  const pub = JSON.parse(fs__default["default"].readFileSync(publicName, "utf8"));
+  const proof = JSON.parse(fs__default["default"].readFileSync(proofName, "utf8"));
+
+  let res = {
+    pub_signal: pub,
+    proof: proof
+  };
+
+  console.log(res);
+
+  return 0;
 }
 
 // powersoftau new <curve> <power> [powersoftau_0000.ptau]",

--- a/cli.js
+++ b/cli.js
@@ -778,7 +778,7 @@ async function zkeyExportSwayCalldata(params, options) {
     proof: proof
   };
 
-  console.log(res);
+  console.log(JSON.stringify(res));
 
   return 0;
 }

--- a/cli.js
+++ b/cli.js
@@ -263,7 +263,7 @@ const commands = [
         cmd: "zkey export swaycalldata [public.json] [proof.json]",
         description: "Generates sway call parameters ready to be called.",
         alias: ["zkeswc", "generateswaycall -pub|public -p|proof"],
-        //action: zkeyExportSwayCalldata
+        action: zkeyExportSwayCalldata
     },
     {
         cmd: "groth16 setup [circuit.r1cs] [powersoftau.ptau] [circuit_0000.zkey]",
@@ -749,6 +749,38 @@ async function zkeyExportSwayVerifier(params, options) {
     fs.writeFileSync(path.join(verifierDir, "main.sw"), mainCode, "utf-8");
 
     return 0;
+}
+
+
+async function zkeyExportSwayCalldata(params, options) {
+  let publicName;
+  let proofName;
+
+  if (params.length < 1) {
+      publicName = "public.json";
+  } else {
+      publicName = params[0];
+  }
+
+  if (params.length < 2) {
+      proofName = "proof.json";
+  } else {
+      proofName = params[1];
+  }
+
+  if (options.verbose) Logger.setLogLevel("DEBUG");
+
+  const pub = JSON.parse(fs.readFileSync(publicName, "utf8"));
+  const proof = JSON.parse(fs.readFileSync(proofName, "utf8"));
+
+  let res = {
+    pub_signal: pub,
+    proof: proof
+  };
+
+  console.log(res);
+
+  return 0;
 }
 
 // powersoftau new <curve> <power> [powersoftau_0000.ptau]",

--- a/templates/verifier_fflonk_lib.sw.ejs
+++ b/templates/verifier_fflonk_lib.sw.ejs
@@ -284,9 +284,8 @@ fn compute_challenges(proof: &Proof, pub_signals: [u256;<%=Math.max(nPublic, 1)%
 
     transcript.append(C0X.to_be_bytes());
     transcript.append(C0Y.to_be_bytes());
-    transcript.append(pub_signals[0].to_be_bytes());
 
-    let mut i = 1;
+    let mut i = 0;
     while i < N_PUBLIC {
         transcript.append(pub_signals[i].to_be_bytes());
         i += 1;

--- a/templates/verifier_groth16_lib.sw.ejs
+++ b/templates/verifier_groth16_lib.sw.ejs
@@ -120,6 +120,6 @@ abi Groth16Verifier {
         p_a: [u256; 2],
         p_b: [[u256; 2]; 2],
         p_c: [u256; 2],
-        pub_signals: [u256; <%=IC.length-1%>],
+        pub_signal: [u256; <%=IC.length-1%>],
     ) -> bool;
 }

--- a/templates/verifier_groth16_main.sw.ejs
+++ b/templates/verifier_groth16_main.sw.ejs
@@ -8,8 +8,8 @@ impl Groth16Verifier for Contract {
     p_a: [u256; 2],
     p_b: [[u256; 2]; 2],
     p_c: [u256; 2],
-    pub_signals: [u256; <%=IC.length-1%>],
+    pub_signal: [u256; <%=IC.length-1%>],
 ) -> bool {
-  return verify_proof(p_a, p_b, p_c, pub_signals);
+  return verify_proof(p_a, p_b, p_c, pub_signal);
 }
 }

--- a/templates/verifier_plonk_lib.sw.ejs
+++ b/templates/verifier_plonk_lib.sw.ejs
@@ -161,7 +161,7 @@ pub struct Proof {
 }
 
 abi PlonkVerifier {
-  fn verify(proof: Proof, pubInput: [u256;<%=nPublic%>]) -> bool;
+  fn verify(proof: Proof, pub_signal: [u256;<%=nPublic%>]) -> bool;
 }
 
 impl u256 {

--- a/templates/verifier_plonk_main.sw.ejs
+++ b/templates/verifier_plonk_main.sw.ejs
@@ -4,7 +4,7 @@ mod lib;
 use lib::{PlonkVerifier, Proof};
 
 impl PlonkVerifier for Contract {
-  fn verify(proof: Proof, pubInput: [u256;<%=nPublic%>]) -> bool {
-      proof.verify(pubInput)
+  fn verify(proof: Proof, pub_signal: [u256;<%=nPublic%>]) -> bool {
+      proof.verify(pub_signal)
   }
 }


### PR DESCRIPTION
Added export sway calldata and renamed all public input for verifiers to pub_signal.
The command can be used with `node build/cli.cjs zkey export swaycalldata <path_to_public_input> <path_to_proof>`.

